### PR TITLE
Add atomicparsley as a dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -x && \
     KEPT_PACKAGES+=(python3) && \
     KEPT_PACKAGES+=(rtmpdump) && \
     KEPT_PACKAGES+=(zip) && \
+	KEPT_PACKAGES+=(atomicparsley) && \
     # Install packages
     apt-get update -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
[youtube-dl](https://github.com/ytdl-org/youtube-dl) uses [atomicparsley](http://atomicparsley.sourceforge.net/) as a dependency to allow embedding thumbnails. This PR adds it as a dependency so that [feature](https://github.com/ytdl-org/youtube-dl#post-processing-options) works when using the docker image.