### PR TITLE
Add aria2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:sid-slim
 
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
@@ -19,12 +19,13 @@ RUN set -x && \
     KEPT_PACKAGES+=(ffmpeg) && \
     KEPT_PACKAGES+=(locales) && \
     KEPT_PACKAGES+=(locales-all) && \
-    KEPT_PACKAGES+=(mplayer) && \
     KEPT_PACKAGES+=(mpv) && \
     KEPT_PACKAGES+=(python3) && \
+    KEPT_PACKAGES+=(python-is-python3) && \
     KEPT_PACKAGES+=(rtmpdump) && \
     KEPT_PACKAGES+=(zip) && \
-	KEPT_PACKAGES+=(atomicparsley) && \
+    KEPT_PACKAGES+=(atomicparsley) && \
+    KEPT_PACKAGES+=(aria2) && \
     # Install packages
     apt-get update -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
For downloading with `--external-downloader aria2c`

Also few more fixes:
- Use sid distribution for newer packages (might be relevant for ffmpeg/aria2/mpv/etc)
- python-is-python3 creates /usr/bin/python symlink which is required by youtube-dl
- Remove mplayer because it's superseded by mpv and that will reduce image size;
  youtube-dl should be able to use mpv instead of mplayer for MMS and RTSP