### PR TITLE
add package adduser to install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -x && \
     KEPT_PACKAGES+=(zip) && \
     KEPT_PACKAGES+=(atomicparsley) && \
     KEPT_PACKAGES+=(aria2) && \
+    KEPT_PACKAGES+=(adduser) && \
     # Install packages
     apt-get update -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
It appears that `sid-slim` no longer provides `adduser` and `addgroup` by default, producing an error in the entrypoint script. Explicitly installing the `adduser` package brings them back.