### PR TITLE
fix filename of yt-dlp's config file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       # Test container build for all supported platforms (defined above)
       -
         name: Test Build ${{ matrix.docker-platform }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           tags: youtube-dl:testing

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker run \
 Where:
 
 * `/path/to/downloaded/videos` is where youtube-dl will download videos to (use `"$(pwd)"` to downloade to current working directory.
-* `/path/to/yt-dlp.conf` is the path to your youtube-dl.conf file.
+* `/path/to/yt-dlp.conf` is the path to your yt-dlp.conf file.
 
 ## Authentication using `.netrc`
 

--- a/init
+++ b/init
@@ -5,14 +5,14 @@ mkdir -p /home/dockeruser
 
 # Create symlinks for files/dirs under /config
 
-# if /config/youtube-dl.conf exists, symlink to /etc/youtube-dl.conf
-if [[ -e "/config/youtube-dl.conf" ]]; then
+# if /config/yt-dlp.conf exists, symlink to /etc/yt-dlp.conf
+if [[ -e "/config/yt-dlp.conf" ]]; then
     # if the symlink already exists, remove it
-    if [[ -L "/etc/youtube-dl.conf" ]]; then
-        rm -v "/etc/youtube-dl.conf"
+    if [[ -L "/etc/yt-dlp.conf" ]]; then
+        rm -v "/etc/yt-dlp.conf"
     fi
     # create symlink
-    ln -vs "/config/youtube-dl.conf" "/etc/youtube-dl.conf" > /dev/null 2>&1 || true
+    ln -vs "/config/yt-dlp.conf" "/etc/yt-dlp.conf" > /dev/null 2>&1 || true
 fi
 
 # if /config/.netrc exists, symlink to /home/dockeruser/.netrc


### PR DESCRIPTION
updated `readme.md` and `init` with the correct path that `yt-dlp` expects for it's config file.  

fixes https://github.com/mikenye/docker-youtube-dl/issues/44